### PR TITLE
chore(ci): update GitHub Actions workflow to use JDK 17 and latest ac…

### DIFF
--- a/.github/workflows/android_fastlane_firebase_app_distribution_workflow.yml
+++ b/.github/workflows/android_fastlane_firebase_app_distribution_workflow.yml
@@ -1,0 +1,49 @@
+name: Android Fastlane with Firebase App Distribution Workflow
+
+on:
+  push:
+    branches:
+      - main # غيّرها لـ master لو هو الفرع الأساسي عندك
+
+jobs:
+  distribute_to_firebase:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Flutter Pub Get
+        run: flutter pub get
+
+      - name: Setup Ruby & Fastlane
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2.3"
+          bundler-cache: true
+          working-directory: android
+
+      - name: Build and Distribute App to Firebase
+        env:
+          FIREBASE_CLI_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}
+        run: |
+          bundle exec fastlane android release_to_firebase
+        working-directory: android
+
+      # Upload APK as Artifact (optional but useful)
+      - name: Upload APK Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release
+          path: build/app/outputs/flutter-apk/*.apk

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -9,7 +9,7 @@ platform :android do
 
     firebase_app_distribution(
       app: "1:754897613485:android:8cea1548a7dd94d6874c24",
-      firebase_cli_token: "1//03gh-rMkmxGo3CgYIARAAGAMSNgF-L9Ir1WpaMDNLS4g8gJXUU5FEtP9KZfMPmdYA87lO7TdLhyb1B6kpUy3hWfOdL0s2eM5X4Q",
+      firebase_cli_token: ENV["firebase_cli_token"],
       android_artifact_type: "APK",
       android_artifact_path: "../build/app/outputs/flutter-apk/app-production-release.apk",
       testers: "aelbaz0189@gmail.com",

--- a/android/fastlane/report.xml
+++ b/android/fastlane/report.xml
@@ -5,22 +5,22 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.002453">
+      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.0020281">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="1: flutter clean" time="3.157265">
+      <testcase classname="fastlane.lanes" name="1: flutter clean" time="2.8434376">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="2: flutter build apk --release --flavor production --target lib/main_production.dart --no-tree-shake-icons" time="94.2790177">
+      <testcase classname="fastlane.lanes" name="2: flutter build apk --release --flavor production --target lib/main_production.dart --no-tree-shake-icons" time="140.2851868">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="3: firebase_app_distribution" time="222.2986407">
+      <testcase classname="fastlane.lanes" name="3: firebase_app_distribution" time="163.3099572">
         
       </testcase>
     


### PR DESCRIPTION
…tions

- Switched from JDK 11 → JDK 17 to support Android Gradle Plugin 8.x
- Updated actions/checkout to v4
- Updated actions/upload-artifact to v4
- Ensured compatibility with Firebase App Distribution lane