### PR TITLE
Feature/flavors

### DIFF
--- a/.github/workflows/android_fastlane_firebase_app_distribution_workflow.yml
+++ b/.github/workflows/android_fastlane_firebase_app_distribution_workflow.yml
@@ -31,8 +31,19 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2.3"
-          bundler-cache: true
+          bundler-cache: false   # نخلي الكاش false علشان نتحكم في bundler
           working-directory: android
+
+      - name: Add Linux platform to Gemfile.lock
+        working-directory: android
+        run: |
+          bundle lock --add-platform x86_64-linux || true
+          bundle lock --add-platform x64-mingw-ucrt || true
+          bundle lock --add-platform x86_64-darwin-21 || true
+
+      - name: Install dependencies (bundle install)
+        working-directory: android
+        run: bundle install --jobs 4
 
       - name: Build and Distribute App to Firebase
         env:

--- a/android/Gemfile.lock
+++ b/android/Gemfile.lock
@@ -227,6 +227,7 @@ GEM
 
 PLATFORMS
   x64-mingw-ucrt
+  x86_64-linux
 
 DEPENDENCIES
   fastlane

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 1.0.2+1
 
 environment:
   sdk: ^3.9.2


### PR DESCRIPTION

chore(ci): update Ruby setup to disable bundler cache and add Linux platform support to Gemfile.lock
fix: update version to 1.0.2+1 in pubspec.yaml
